### PR TITLE
Fix: Query data and Export Data Job polling infinitely loading

### DIFF
--- a/docker/src/utils/data_utils.py
+++ b/docker/src/utils/data_utils.py
@@ -9,30 +9,48 @@ QUERY_DATA_QUEUE_TIMEOUT = os.getenv("QUERY_DATA_QUEUE_TIMEOUT") or 120
 QUERY_DATA_QUERY_EXECUTION_TIMEOUT = os.getenv("QUERY_DATA_QUERY_EXECUTION_TIMEOUT") or 30
 
 
+def poll_job_completion(bulk, job_id, status_messages, polling_interval=None, queue_timeout=None, execution_timeout=None):
+    if polling_interval is None:
+        polling_interval = QUERY_DATA_POLLING_INTERVAL
+    if queue_timeout is None:
+        queue_timeout = QUERY_DATA_QUEUE_TIMEOUT
+    if execution_timeout is None:
+        execution_timeout = QUERY_DATA_QUERY_EXECUTION_TIMEOUT
+    start_time = time.time()
+    processing_start_time = None
+    while True:
+        job_details = bulk.get_export_job_details(job_id)
+        current_time = time.time()
+        if job_details['jobCode'] == '1004': # code for JOB COMPLETED
+            break
+        elif job_details['jobCode'] == '1003': # code for ERROR OCCURRED
+            return status_messages.get('error', "Some internal error occurred. Please try again later.")
+        elif job_details['jobCode'] == '1001': # code for JOB NOT INITIATED
+            if current_time - start_time > queue_timeout:
+                return status_messages.get('queue_timeout', "Job accepted, but queue processing is slow. Please try again later.")
+        elif job_details['jobCode'] == '1002': # code for JOB IN PROGRESS
+            if processing_start_time is None:
+                processing_start_time = current_time
+            elif current_time - processing_start_time > execution_timeout:
+                return status_messages.get('execution_timeout', "Job is taking too long to execute. Please try again later.")
+        time.sleep(polling_interval)
+    return None
+
+
 def query_data_implementation(org_id, workspace_id, sql_query):
     try:
         file_path = "/tmp/query_data_result.csv"
         analytics_client = get_analytics_client_instance()
         bulk = analytics_client.get_bulk_instance(org_id, workspace_id)
         job_id = bulk.initiate_bulk_export_using_sql(sql_query, "CSV")
-        start_time = time.time()
-        processing_start_time = None
-        while True:
-            job_details = bulk.get_export_job_details(job_id)
-            current_time = time.time()
-            if job_details['jobStatus'] == 'JOB COMPLETED':
-                break
-            elif job_details['jobStatus'] == 'ERROR OCCURED':
-                return "Some internal error ocurred (Not likely due to the query). Please try again later."
-            elif job_details['jobStatus'] == 'JOB ON QUEUE':
-                if current_time - start_time > QUERY_DATA_QUEUE_TIMEOUT:
-                    return "Query Job accepted, but queue processing is slow. Please try again later."
-            elif job_details['jobStatus'] == 'JOB INITIATED':
-                if processing_start_time is None:
-                    processing_start_time = current_time
-                elif current_time - processing_start_time > QUERY_DATA_QUERY_EXECUTION_TIMEOUT:
-                    return "Query is taking too long to execute, maybe due to the complexity. Please try a simpler query"
-            time.sleep(QUERY_DATA_POLLING_INTERVAL)
+        status_messages = {
+            'error': "Some internal error ocurred (Not likely due to the query). Please try again later.",
+            'queue_timeout': "Query Job accepted, but queue processing is slow. Please try again later.",
+            'execution_timeout': "Query is taking too long to execute, maybe due to the complexity. Please try a simpler query"
+        }
+        error_message = poll_job_completion(bulk, job_id, status_messages)
+        if error_message:
+            return error_message
         file_path = "/tmp/" + job_id + ".csv"
         bulk = analytics_client.get_bulk_instance(org_id, workspace_id)
         bulk.export_bulk_data(job_id, file_path)
@@ -82,26 +100,14 @@ def export_view_implementation(org_id, response_file_format, response_file_path,
             if response_file_format != "pdf":
                 return f"Exporting view {view_id} in {response_file_format} format is not supported. Please use 'pdf' format for dashboards."
             job_id = bulk.initiate_bulk_export(view_id, response_format="pdf", config={"dashboardLayout":1})
-            # The below logic is the same as the one used in query_data tool to poll the job status.
-            # Need to write it as a common function in the future to avoid duplication.
-            start_time = time.time()
-            processing_start_time = None
-            while True:
-                job_details = bulk.get_export_job_details(job_id)
-                current_time = time.time()
-                if job_details['jobStatus'] == 'JOB COMPLETED':
-                    break
-                elif job_details['jobStatus'] == 'JOB ERROR OCCURED':
-                    return "Some internal error ocurred. Please try again later."
-                elif job_details['jobStatus'] == 'JOB ON QUEUE':
-                    if current_time - start_time > QUERY_DATA_QUEUE_TIMEOUT:
-                        return "Dashboard export Job accepted, but queue processing is slow. Please try again later."
-                elif job_details['jobStatus'] == 'JOB INITIATED':
-                    if processing_start_time is None:
-                        processing_start_time = current_time
-                    elif current_time - processing_start_time > QUERY_DATA_QUERY_EXECUTION_TIMEOUT:
-                        return "Dashboard is taking too long to export, maybe due to the complexity. Please try a again later."
-                time.sleep(QUERY_DATA_POLLING_INTERVAL)
+            status_messages = {
+                'error': "Some internal error ocurred. Please try again later.",
+                'queue_timeout': "Dashboard export Job accepted, but queue processing is slow. Please try again later.",
+                'execution_timeout': "Dashboard is taking too long to export, maybe due to the complexity. Please try a again later."
+            }
+            error_message = poll_job_completion(bulk, job_id, status_messages)
+            if error_message:
+                return error_message
             bulk.export_bulk_data(job_id, response_file_path)
     return f"Object exported successfully to {response_file_path} in {response_file_format} format."
 


### PR DESCRIPTION
The query_data tool call and export_view tool call sometimes loads infinitely. This is due to the polling logic containing a typo on the status check.

1. Have changed the polling logic to use status code rather than status text.
2. Wrote a common utility function to de-duplicate code across query_data as well as export_view