### PR TITLE
Fix /mcp 307 redirect that breaks Claude.ai auth

### DIFF
--- a/docker/src/http_server.py
+++ b/docker/src/http_server.py
@@ -9,6 +9,7 @@ from src.logging_util import configure_logging, get_logger
 from src.auth.remote_auth import AuthMiddleware
 from src.config import Settings
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Scope, Receive, Send
 # from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 import asyncio
@@ -76,6 +77,30 @@ async def lifespan(app: FastAPI):
 
 mcp_server = mcp.http_app(transport="streamable-http", path="/")
 
+
+class MCPPathNormalizer:
+    """Rewrite ``/mcp`` to ``/mcp/`` at the ASGI scope level.
+
+    Starlette's ``Mount`` returns 307 Temporary Redirect for the bare
+    mount path so the trailing slash is added. MCP clients that POST to
+    ``/mcp`` (e.g. Claude.ai) do not preserve the ``Authorization``
+    header across the redirect, so the next request is treated as
+    unauthenticated and the connection fails with an authorization
+    error. Rewriting the scope path before routing avoids the redirect
+    entirely and makes ``/mcp`` and ``/mcp/`` behave identically.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") == "http" and scope.get("path") == "/mcp":
+            scope = dict(scope)
+            scope["path"] = "/mcp/"
+            scope["raw_path"] = b"/mcp/"
+        await self.app(scope, receive, send)
+
+
 def create_app() -> FastAPI:
     app = FastAPI(lifespan=lifespan)
     app.mount("/static", StaticFiles(directory="src/static"), name="static")
@@ -94,7 +119,7 @@ def create_app() -> FastAPI:
     return app
 
 
-app = create_app()
+app = MCPPathNormalizer(create_app())
 
 # This is required for testing with inspector. Uncomment when needed.
 # app.add_middleware(


### PR DESCRIPTION
## Problem

`POST /mcp` (no trailing slash) is returned as `307 Temporary Redirect` to `/mcp/`, which silently breaks authentication for some MCP clients.

### Reproduction

1. Deploy the remote MCP server with a public URL.
2. Configure an MCP client (e.g. Claude.ai) using the URL exactly as the OAuth metadata advertises it — `https://<host>/mcp` (no trailing slash). This URL is what `src/auth/remote_auth.py` returns as `mcp_url` (`Settings.MCP_SERVER_PUBLIC_URL.rstrip("/") + "/mcp"`).
3. Complete the OAuth + consent flow. The container logs confirm the upstream token exchange against `accounts.zoho.com` returns 200.
4. The client immediately POSTs to `/mcp` with its bearer token. Logs show:

   ```
   "POST /mcp HTTP/1.1" 307 Temporary Redirect
   "POST /mcp HTTP/1.1" 307 Temporary Redirect
   ```

5. The client surfaces a generic error such as *"Authorization with the MCP server failed."* even though authentication actually succeeded — the failure happens after the token is already valid.

### Root cause

`docker/src/http_server.py:93` mounts the streamable-HTTP MCP app at `/mcp`:

```python
app.mount("/mcp", mcp_server)
```

Starlette's `Mount` always responds to a request for the bare mount path with a 307 redirect to the same path with a trailing slash, so any request to `/mcp` is redirected to `/mcp/`. Several MCP clients (Claude.ai is the one I verified, but the behavior is plausibly shared by others) do not preserve the `Authorization` header across that redirect — RFC 9110 §15.4.8 lets clients drop credentials on cross-resource redirects, and at least one popular client treats the path change as cross-resource. The result is a request loop where the token is valid but the server keeps seeing unauthenticated retries until the client gives up.

The advertised URL (`mcp_url`) and the actual route shape disagree by exactly one character, and that character costs the entire connection.

## Fix

Wrap the FastAPI app with a small ASGI middleware that rewrites a request path of exactly `/mcp` to `/mcp/` at the scope level — before any routing, mount lookup, or auth middleware runs. This makes `/mcp` and `/mcp/` behave identically without an HTTP-level redirect, so the bearer token survives the first request.

The change is in `docker/src/http_server.py` only:

- Adds a `MCPPathNormalizer` class (8 lines of logic + docstring).
- Wraps the existing `create_app()` return value: `app = MCPPathNormalizer(create_app())`.
- No change to `create_app()` itself, no change to the mount point, no change to any other route or middleware.

Because the wrapper sits at the outermost ASGI layer it does not interfere with `SessionMiddleware`, `AuthMiddleware`, `MaxBodySizeMiddleware`, the OAuth router, or the lifespan handler. The lifespan event passes through unchanged because the rewrite only triggers on `scope["type"] == "http"` and only when the path is exactly `/mcp`.

## Verification

Reproduced with `zohoanalytics/mcp-server:remote-v1.1` deployed behind Azure Container Apps ingress and connected from Claude.ai. Before the fix, every authenticated `POST /mcp` returned 307 and the client failed with "Authorization with the MCP server failed." After applying this change to a running container (via the same logic injected at startup), the same client connected successfully on the first request and tool calls worked end-to-end. The `Missing Authorization header for path: ...` log line confirms the auth middleware now sees `/mcp/` directly with no intermediate redirect.

## Notes

- An equivalent fix would be to mount the MCP app at `/` with `path="/mcp"` configured on the inner app, but that would shadow `/authorize`, `/token`, `/register`, and `/auth/callback`, so the middleware approach is safer.
- I considered disabling `redirect_slashes` on the Starlette router, but that flag is not exposed by `app.mount()` and is also broader than needed.
