### PR TITLE
Dependency and security patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ or simply add the <mcp-server-url> in the corresponding location the MCP host re
     </tr>
     <tr>
       <td>MCP_SERVER_ORG_IDS</td>
-      <td>Comma-separated list of Zoho Analytics org IDs whose users are allowed to use the Remote MCP server</td>
+      <td>Comma-separated list of Zoho Analytics org IDs whose users are allowed to use the Remote MCP server. This setting controls server admission only. Once authenticated, users can access any Zoho Analytics organization they are already authorized to access through their account.</td>
     </tr>
     <tr>
       <td>STORAGE_BACKEND</td>
@@ -394,16 +394,6 @@ The Zoho Analytics MCP server provides various tools for interacting with Zoho A
       <td>delete_view</td>
       <td>Delete View</td>
       <td>Deletes a view (table, report, or dashboard) from a workspace.</td>
-    </tr>
-    <tr>
-      <td>analyse_file_structure</td>
-      <td>Not Applicable</td>
-      <td>Analyzes the structure of a CSV or JSON file to determine its columns and data types.</td>
-    </tr>
-    <tr>
-      <td>download_file</td>
-      <td>Not Applicable</td>
-      <td>Downloads a file from a given URL and saves it to a local directory.</td>
     </tr>
   </tbody>
 </table>

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -51,7 +51,6 @@ opentelemetry-instrumentation==0.60b1
 opentelemetry-sdk==1.39.1
 opentelemetry-semantic-conventions==0.60b1
 packaging==25.0
-pandas==2.2.3
 pathable==0.4.4
 pathvalidate==3.3.1
 platformdirs==4.5.1

--- a/docker/src/http_server.py
+++ b/docker/src/http_server.py
@@ -1,9 +1,9 @@
 from fastapi.responses import JSONResponse
+Settings.HOSTED_LOCATION = Settings.CONSTANT_REMOTE_HOSTED_LOCATION
 import src.tools # Do not remove this import, it is required to register the tools with the MCP server.
 from src.mcp_instance import mcp
 from fastapi import FastAPI, Request
 import uvicorn
-import debugpy
 from src.auth.remote_auth import authRouter
 from src.logging_util import configure_logging, get_logger
 from src.auth.remote_auth import AuthMiddleware
@@ -20,7 +20,6 @@ from src.utils.security import MaxBodySizeMiddleware
 from fastapi.exceptions import RequestValidationError
 from src.utils.exceptions import validation_exception_handler
 
-Settings.HOSTED_LOCATION = Settings.CONSTANT_REMOTE_HOSTED_LOCATION
 
 configure_logging(
     level="INFO",              # overall minimum
@@ -38,6 +37,7 @@ configure_logging(
 
 logger = get_logger(__name__)
 # Uncomment below line to start the debugger
+# import debugpy
 # debugpy.listen(("0.0.0.0", 5678))
 
 @asynccontextmanager

--- a/docker/src/http_server.py
+++ b/docker/src/http_server.py
@@ -1,4 +1,5 @@
 from fastapi.responses import JSONResponse
+from src.config import Settings
 Settings.HOSTED_LOCATION = Settings.CONSTANT_REMOTE_HOSTED_LOCATION
 import src.tools # Do not remove this import, it is required to register the tools with the MCP server.
 from src.mcp_instance import mcp
@@ -7,7 +8,6 @@ import uvicorn
 from src.auth.remote_auth import authRouter
 from src.logging_util import configure_logging, get_logger
 from src.auth.remote_auth import AuthMiddleware
-from src.config import Settings
 from starlette.middleware.sessions import SessionMiddleware
 # from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles

--- a/docker/src/tools/data_tools.py
+++ b/docker/src/tools/data_tools.py
@@ -4,118 +4,12 @@ import os
 import json
 import urllib
 import requests
-import pandas as pd
 from src.utils.analytics.common import retry_with_fallback
 from src.utils.analytics.data import QUERY_DATA_ROW_LIMIT, import_data_implementation, export_view_implementation, query_data_implementation
 import traceback
 from fastmcp.server.dependencies import get_context
 from sql_limit_enforcer import enforce_limit
 
-@mcp.tool()
-async def analyze_file_structure(file_path: str) -> dict:
-    """
-    <use_case>
-    1. Analyzes the structure of a file (CSV or JSON) to determine its columns and data types.
-    2. This can be used to understand the structure of a file before importing it into Zoho Analytics.
-    3. If the table does not already exist and a file needs to be imported, this tool can be used to analyze the file structure and create a new table with the appropriate columns. 
-    </use_case>
-
-    <important_notes>
-    - This tool supports only local files. If the file is a remote URL, download it first using the download_file tool.
-    - The returned data types will not be the exact data types used in Zoho Analytics, but rather a general representation of the data types in Python.
-    </important_notes>
-
-    <arguments>
-        file_path (str): The path to the local file to be analyzed.
-    </arguments>
-
-    <returns>
-        A dictionary containing the column names and their respective data types.
-    </returns>
-    """
-    
-    try:
-        if not os.path.exists(file_path):
-            return file_path + " does not exist. Please provide a valid file path."
-
-        if file_path.endswith('.csv'):
-            df = pd.read_csv(file_path)
-            structure = {col: str(df[col].dtype) for col in df.columns}
-            return structure
-        
-        elif file_path.endswith('.json'):
-            with open(file_path, 'r') as f:
-                json_data = json.load(f)
-            
-
-            if isinstance(json_data, list) and len(json_data) > 0:
-
-                first_object = json_data[0]
-                structure = {}
-                
-                for column, value in first_object.items():
-                    if isinstance(value, int):
-                        structure[column] = 'NUMBER'
-                    elif isinstance(value, float):
-                        structure[column] = 'DECIMAL'
-                    elif isinstance(value, bool):
-                        structure[column] = 'BOOLEAN'
-                    else:
-                        structure[column] = 'TEXT'
-                
-                return structure
-            else:
-                return "Invalid JSON format. Expected a list of objects."
-        
-        else:
-            return "Unsupported file type. Please provide a CSV or JSON file."
-    
-    except Exception as e:
-        ctx = get_context()
-        await ctx.error(traceback.format_exc())
-        return f"An error occurred while analyzing the file structure: {e}"
-
-@mcp.tool()
-async def download_file(file_url: str) -> str:
-    """
-    <use_case>
-    1. Downloads a file from a given URL and saves it to a local directory.
-    2. This can be used to download files that need to be imported into Zoho Analytics.
-    </use_case>
-
-    <arguments>
-        file_url (str): The URL of the file to be downloaded.
-    </arguments>
-
-    <returns>
-        A string indicating the path where the file has been saved locally.
-    </returns>
-    """
-
-    try:
-
-        download_dir = Settings.MCP_DATA_DIR
-        os.makedirs(download_dir, exist_ok=True)
-
-        filename = os.path.basename(urllib.parse.urlparse(file_url).path)
-        file_type = file_url.split('.')[-1].lower()
-        if not filename:
-            filename = f"downloaded_file.{file_type}"
-
-        downloaded_path = os.path.join(download_dir, filename)
-        response = requests.get(file_url, stream=True)
-        response.raise_for_status()
-
-        with open(downloaded_path, 'wb') as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-
-        return f"File downloaded successfully and saved to {downloaded_path}"
-    
-    except Exception as e:
-        ctx = get_context()
-        await ctx.error(traceback.format_exc())
-        return "Failed to download the file. Please check the URL and try again. Please make sure the file is accessible and the URL is correct."
 
 @mcp.tool()
 async def import_data(workspace_id: str, table_id: str, data: list[dict] | None = None, file_path: str | None = None, file_type: str | None = None, org_id: str | None = None) -> str:
@@ -129,7 +23,7 @@ async def import_data(workspace_id: str, table_id: str, data: list[dict] | None 
     - Make sure the the table already exists in the workspace before importing data.
     - If no table exists, create a table first using the create_table tool before importing the data.
     - if the file_path is a remote URL, download the file using download_file tool before using this tool.
-    - if the file_path is a remote URL and table does not exist, you can create a new table using the create_table tool, analyse the structure (column structure of the table) of the file using analyse_file_structure tool and then import the data.
+    - if the file_path is a remote URL and table does not exist, you can create a new table using the create_table tool, analyse the structure of the file first, then create the table and  import the data.
     </important_notes>
 
 
@@ -268,7 +162,5 @@ async def query_data(workspace_id: str, sql_query: str, org_id: str | None = Non
     
 
 if Settings.HOSTED_LOCATION == Settings.CONSTANT_REMOTE_HOSTED_LOCATION:
-    analyze_file_structure.disable()
-    download_file.disable()
     import_data.disable()
     export_view.disable()

--- a/docker/src/utils/analytics/data.py
+++ b/docker/src/utils/analytics/data.py
@@ -87,9 +87,25 @@ async def import_data_implementation(org_id, workspace_id, file_path, table_id, 
     if file_path:
         if file_path.startswith("https"):
             return "File path cannot be a remote URL. Please download the file using the download_file tool and provide the local file path."
-        file_exists = await asyncio.to_thread(os.path.exists, file_path)
+        
+
+        mcp_data_dir = getattr(Settings, "MCP_DATA_DIR", None)
+        if not mcp_data_dir:
+            return "MCP_DATA_DIR is not configured. It is required for the importData tool to work properly. Please set MCP_DATA_DIR to the directory from which file imports are permitted."
+
+        normalized_root = os.path.realpath(mcp_data_dir)
+        tentative_path = os.path.realpath(file_path)
+        if tentative_path == normalized_root or tentative_path.startswith(normalized_root + os.sep):
+            resolved_file_path = tentative_path
+        else:
+            resolved_file_path = os.path.realpath(os.path.join(normalized_root, file_path))
+            if resolved_file_path != normalized_root and not resolved_file_path.startswith(normalized_root + os.sep):
+                return f"The provided file path resolves outside the allowed MCP_DATA_DIR directory ({normalized_root}). Please provide a file path that is within the allowed root."
+
+        
+        file_exists = await asyncio.to_thread(os.path.exists, resolved_file_path)
         if not file_exists:
-            return f"File {file_path} does not exist. Please provide a valid local file path."
+            return f"File {resolved_file_path} does not exist. Please provide a valid local file path."
         if file_type not in ["csv", "json"]:
             return "Invalid file type. Please provide 'csv' or 'json'."
         result = await asyncio.to_thread(
@@ -98,7 +114,7 @@ async def import_data_implementation(org_id, workspace_id, file_path, table_id, 
             "append", 
             file_type, 
             "true", 
-            file_path, 
+            resolved_file_path, 
             config={"delimiter":'0'}
         )
         return result
@@ -119,6 +135,18 @@ async def import_data_implementation(org_id, workspace_id, file_path, table_id, 
 async def export_view_implementation(org_id, response_file_format, response_file_path, workspace_id, view_id):
     if response_file_format not in ["csv", "json", "xml", "xls", "pdf", "html", "image"]:
         return "Invalid response file format. Supported formats are ['csv', 'json', 'xml', 'xls', 'pdf', 'html', 'image']."
+
+
+    mcp_data_dir = getattr(Settings, "MCP_DATA_DIR", None)
+    if not mcp_data_dir:
+        return "MCP_DATA_DIR is not configured. It is required for the exportView tool to work properly. Please set MCP_DATA_DIR to a writable directory."
+
+    normalized_root = os.path.realpath(mcp_data_dir)
+    resolved_file_path = os.path.realpath(response_file_path)
+    if resolved_file_path != normalized_root and not resolved_file_path.startswith(normalized_root + os.sep):
+        return f"The provided file path resolves outside the allowed MCP_DATA_DIR directory ({normalized_root}). Please provide a file path that is within the allowed root."
+
+
 
     analytics_client = get_analytics_client_instance()
     bulk = analytics_client.get_bulk_instance(org_id, workspace_id)

--- a/node/README.md
+++ b/node/README.md
@@ -177,16 +177,6 @@ The Zoho Analytics MCP server provides various tools for interacting with Zoho A
       <td>Delete View</td>
       <td>Deletes a view (table, report, or dashboard) from a workspace.</td>
     </tr>
-    <tr>
-      <td>analyse_file_structure</td>
-      <td>Not Applicable</td>
-      <td>Analyzes the structure of a CSV or JSON file to determine its columns and data types.</td>
-    </tr>
-    <tr>
-      <td>download_file</td>
-      <td>Not Applicable</td>
-      <td>Downloads a file from a given URL and saves it to a local directory.</td>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This PR contains the following changes:

1) Clarification of a documentation ambiguity related to MCP_SERVER_ORG_IDS environment variable in remote deployments. It is to clarify that this environment vairable setting only controls server admission and authenticated users can access any organization that is authorized for their account.

2) Depreciating of analyse_file_structure and download_file tools in docker version (both remote and local) of mcp servers. These tools were added at the earlier stages of MCP Servers but modern MCP hosts have these tools in built into them as system functionalities.

3) Removal of pandas library as a requirement since this was only used in analyse file structure. But since the tool is being depreciated. This library doesn't have usages left in the application.

4) Addition of PATH traversal security mechanisms in export_view and import_view tool calls.

5) Setting  before tool imports so the unnecessary tools (export/import related tools) are disabled by default in remote deployments.

6) Removal of debugpy dependency in production builds and commenting out of debugpy imports and usages.